### PR TITLE
Fix to prevent using unphysical bulk concentration values

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -38,10 +38,10 @@ jobs:
 
       - name: Setup environmental variables
         run: |
-          echo ::set-env name=CHOMBO_HOME::$(echo $HOME)/chombo/lib
-          echo ::set-env name=CHOMBO_ROOT::$(echo $HOME)/chombo
-          echo ::set-env name=HDF5_PATH::$(echo $HOME)/hdf5-dir
-          echo ::set-env name=LD_LIBRARY_PATH::$(echo $LD_LIBRARY_PATH):$(echo $HDF5_PATH)/lib
+          echo "CHOMBO_HOME=$(echo $HOME)/chombo/lib" >> $GITHUB_ENV
+          echo "CHOMBO_ROOT=$(echo $HOME)/chombo" >> $GITHUB_ENV
+          echo "HDF5_PATH=$(echo $HOME)/hdf5-dir" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH):$(echo $HDF5_PATH)/lib" >> $GITHUB_ENV
 
       - name: Info
         run: |

--- a/.github/workflows/pythonUnitTest.yaml
+++ b/.github/workflows/pythonUnitTest.yaml
@@ -25,12 +25,11 @@ jobs:
 
       - name: Setup environmental variables
         run: |
-          echo ::set-env name=CHOMBO_HOME::$(echo $HOME)/chombo/lib
-          echo ::set-env name=CHOMBO_ROOT::$(echo $HOME)/chombo
-          echo ::set-env name=HDF5_PATH::$(echo $HOME)/hdf5-dir
-          echo ::set-env name=LD_LIBRARY_PATH::$(echo $LD_LIBRARY_PATH):\
-            $(echo $HDF5_PATH)/lib
-          echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+          echo "CHOMBO_HOME=$(echo $HOME)/chombo/lib" >> $GITHUB_ENV
+          echo "CHOMBO_ROOT=$(echo $HOME)/chombo" >> $GITHUB_ENV
+          echo "HDF5_PATH=$(echo $HOME)/hdf5-dir" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH):$(echo $HDF5_PATH)/lib" >> $GITHUB_ENV
+          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV""
 
       - name: Setup latex
         run: |

--- a/.github/workflows/pythonUnitTest.yaml
+++ b/.github/workflows/pythonUnitTest.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "CHOMBO_ROOT=$(echo $HOME)/chombo" >> $GITHUB_ENV
           echo "HDF5_PATH=$(echo $HOME)/hdf5-dir" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH):$(echo $HDF5_PATH)/lib" >> $GITHUB_ENV
-          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV""
+          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
 
       - name: Setup latex
         run: |

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "${env:CHOMBO_HOME}/include/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/clang-6.0",
+            "cStandard": "c11",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+"configurations": [
+    {
+        "name": "(gdb) Launch [DEBUG]",
+        "type": "cppdbg",
+        "request": "launch",
+        "program": "${workspaceFolder}/execSubcycle/mushyLayer2d.Linux.64.mpiCC.gfortran.DEBUG.MPI.ex",
+        "args": ["inputs"],
+        "stopAtEntry": false,
+        "cwd": "${workspaceFolder}/execSubcycle",
+        "environment": [],
+        "externalConsole": false,
+        "MIMode": "gdb",
+        "setupCommands": [
+            {
+                "description": "Enable pretty-printing for gdb",
+                "text": "-enable-pretty-printing",
+                "ignoreFailures": true
+            }
+        ]
+    },
+]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.ChF": "fortran"
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "make all DIM=2",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "options": {
+                "cwd": "execSubcycle"
+            },
+        },
+        {
+            "label": "Build debug",
+            "type": "shell",
+            "command": "make all DIM=2 DEBUG=TRUE OPT=FALSE",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "options": {
+                "cwd": "execSubcycle"
+            },
+        }
+
+    ]
+}

--- a/install.py
+++ b/install.py
@@ -10,7 +10,8 @@ def usage():
 
 def print_var(var_name, is_git):
     if is_git:
-        print("::set-env name=" + var_name + "::{}".format(os.environ[var_name]))
+        # print("::set-env name=" + var_name + "::{}".format(os.environ[var_name]))
+        print(f"echo \"{var_name}={os.environ[var_name]}\" >> $GITHUB_ENV")
     else:
         print('%s=%s' % (var_name, os.environ[var_name]))
 

--- a/src/EnthalpyVariablesF.ChF
+++ b/src/EnthalpyVariablesF.ChF
@@ -31,6 +31,7 @@ C     -----------------------------------------------------------------
       
       
       CHF_MULTIDO[region; i; j; k]
+
         if (H(CHF_IX[i;j;k],comp) .le. H_s(CHF_IX[i;j;k],comp)) then
           porosity(CHF_IX[i;j;k],comp) = 0
         else if ((H(CHF_IX[i;j;k],comp) .gt. H_s(CHF_IX[i;j;k],comp)) .and. (H(CHF_IX[i;j;k],comp) .le. H_e(CHF_IX[i;j;k],comp))) then
@@ -108,17 +109,28 @@ C     -----------------------------------------------------------------
      &     CHF_CONST_REAL[waterDistributionCoeff],
      &     CHF_CONST_REAL[specificHeatRatio],
      &     CHF_CONST_REAL[stefan])
-      REAL_T a,b,c
+      REAL_T a,b,c,validC
+
+C     Following quadratic coarse-fine interpolation, it seems that can have
+C     C < - composition ratio, which is unphysical and can lead to 
+C     porosity = NaN. We want to avoid this. Might eventually make more
+C     sense to construct a coarse-fine interpolator which respects the 
+C     physical constraints on the bulk concentration (C).
+      if (a_C .ge. -compositionRatio) then
+        validC = a_C
+      else
+        validC = -compositionRatio
+C        print *, "WARNING, C=", a_C, "! Setting C=", validC
+      endif
 
       if (stefan .eq. 0) then
          porosity = 1
       else
          a = compositionRatio*(specificHeatRatio -1) + stefan * (waterDistributionCoeff-1)
          b = compositionRatio * (1-2*specificHeatRatio) + H*(1-waterDistributionCoeff)
-     &				- a_C * (specificHeatRatio-1) - waterDistributionCoeff * stefan
-         c =  (compositionRatio + a_C)*specificHeatRatio +
-     &				waterDistributionCoeff * H
-
+     &				- validC * (specificHeatRatio-1) - waterDistributionCoeff * stefan
+         c =  (compositionRatio + validC)*specificHeatRatio +
+     &				waterDistributionCoeff * H		 
          porosity = (-b -sqrt(b*b - 4*a*c))/(2*a);
          
       endif


### PR DESCRIPTION
Coarse-fine interpolation can result in unphysical values of the bulk concentration (< - composition ratio) which then may lead to invalid porosities. Until the coarse-fine interpolation is properly fixed, this should prevent simulations blowing up.