### PR TITLE
Split diri bcs

### DIFF
--- a/BCutil/PhysBCUtil.H
+++ b/BCutil/PhysBCUtil.H
@@ -124,12 +124,12 @@ public:
 	   * The liquid salinity is given by \f$(\Theta_l)_g = - \theta_g\f$  if \f$0 < \chi < 1\f$, and \f$ (\Theta_l)_g = (\Theta_l)_i \f$ otherwise.
 	   *
 	   */
-	  MixedBCTemperatureSalinity,		
+	  MixedBCTemperatureSalinity,
 
 	  /// Multiple Dirichlet Values (#10)
 	  MultiDiri
 
-	  /* jb: Multiple Dirichlet BCs per side, where alternate value is active over the diriBounds vector */
+	  /* jb: Multiple Dirichlet BCs per side, where alternate value is active after diri_switch */
 
 	};
 

--- a/BCutil/PhysBCUtil.cpp
+++ b/BCutil/PhysBCUtil.cpp
@@ -835,7 +835,7 @@ public:
 
                 // This is a special case
 
-	 	            int Tcomp = 0;                        // jb: I assume this is the indexing code to enter the new enthalpy BC into a_state
+	 	            int Tcomp = 0;                        // jb: I assume this is the indexing code to enter the new temperature BC into a_state
 
                 CH_TIME("BCFunctions::MultiDiri");    // jb: not sure what this does, but when i looked at the above example
 		                                        // (BCFunctions::MixedTemperatureSalinityBC) i didn't see it in BCFunctions.cpp
@@ -845,27 +845,28 @@ public:
                 //                                  NonlinearTemperatureBC* residual;
 
                 // Pull alternate BC geometry and value
-                Real alt_val = 0.0, diri_start = 0.0, diri_end = 0.0;      // jb: dummy vars to get modified by input BC vals
+                Real alt_val = 0.0, base_val = 0.0, diri_switch = 0.0;      // jb: dummy vars to get modified by input BC vals
 
 		            if (side == Side::Lo)
 		            {
-		              alt_val = m_params.bcAltValEnthalpyLo.getBC(idir, side);;  // jb: not sure if this is how to properly pull the vals? still wrapping my head
+		              alt_val = m_params.bcAltValTemperatureLo[idir];;  // jb: not sure if this is how to properly pull the vals? still wrapping my head
 		                                                                 // around the whole class/object/method structure of cpp and how to pass variabless
-		              base_val = m_params.bcValEnthalpyLo.getBC(idir, side);;
-		            else
-		              alt_val = m_params.bcAltValEnthalpyHi.getBC(idir, side);;
-		              base_val = m_params.bcValEnthalpyHi.getBC(idir, side);;
+		              base_val = m_params.bcValTemperatureLo[idir];;
+		              diri_switch = m_params.bcDiriSwitchLo[idir];;
 		            }
-		  
-                diri_start = m_params.diriBounds[0];
-		            diri_end = m_params.diriBounds[1];
+		            else
+                    {
+		              alt_val = m_params.bcAltValTemperatureHi[idir];;
+		              base_val = m_params.bcValTemperatureHi[idir];;
+		              diri_switch = m_params.bcDiriSwitchHi[idir];;
+		            }
 
                 Box toRegion = adjCellBox(a_valid, idir, side, 1);
                 toRegion &= a_state.box();
 
                 Real ghostVal = 0.0;
 
-		            // ??? is the box iterator going to sweep throught the boundary s.t. ivto and ivto_interior are
+		            // ??? is the box iterator going to sweep through the boundary s.t. ivto and ivto_interior are
 		            //     the values we want to test to see if they are in the alt_val bounds?
 		            //     i.e. when diri_start < iv_interior < diri_end set ghostVal to alt_val
                 for (BoxIterator bit = BoxIterator(toRegion); bit.ok(); ++bit)
@@ -873,30 +874,37 @@ public:
                   // TODO - should write this in fortran for speed
                   CH_TIME("BCFunctions::MultiDiri::loopOverBox");
 
-		              /* I'm grabbing the locations of the interior boxes as i want to text if they are in the region that should 
+		              /* I'm grabbing the locations of the interior boxes as i want to test if they are in the region that should
 		              get a modified dirichlet BC */
                   IntVect ivto = bit();
                   IntVect iv_interior = ivto - isign*BASISV(idir);
 		              RealVect loc;
 		              Real x, y, z;
-		              getLocation(iv_interior, loc, m_dx);
+		              // getLocation(iv_interior, loc, m_dx);
+		              getLocation(iv_interior, m_dx, x, y, z);
 
 		              /* I think idir is iterating over the direction (in 2D either x or y) and if it is an x idir boundary (vertical wall) i want to see if the
-		              y value of loc is within the diribounds, conversesly in the y direction i want to see if the x value of loc is within the diriBounds   */
+		              y value of loc is greater than diri_switch, conversely in the y direction i want to see if the x value of loc is greater than diri_switch   */
 		              if (idir == 0)
 		              {
-			              if (loc[1] >= diri_start && loc[1] <= diri_end)
-			              {
-			                ghostVal = alt_val;
-			              else
-			                ghostVal = base_val;
-			              }
+                          if (y >= diri_switch)
+                          {
+                              ghostVal = alt_val;
+                          }
+                              else
+                          {
+                              ghostVal = base_val;
+                          }
+                      }
 		              else if (idir == 1)
-			              if (loc[0] >= diri_start && loc[0] <= diri_end)
+                      {
+			              if (x >= diri_switch)
 			              {
-			                ghostVal = alt_val;
+                              ghostVal = alt_val;
+                          }
 			              else
-				              ghostVal = base_val;
+                          {
+			                  ghostVal = base_val;
 			              }
 		              }
 
@@ -906,7 +914,7 @@ public:
                 }
 
 
-              }
+              } // End of MultiDiri
 
               else
               {

--- a/src/MushyLayerParams.cpp
+++ b/src/MushyLayerParams.cpp
@@ -495,6 +495,30 @@ void MushyLayerParams::getParameters()
 
   ppParams.query("enthalpyPlume", HPlumeInflow);
   ppParams.query("bulkConcPlume", ThetaPlumeInflow);
+  
+  
+  
+  
+  //// jb - attempting to add multiple dirichlet BC values option for Enthalpy (maybe Salinity in future)
+  ////    - currently keeping things in one spot, can redistribute after they're checked
+  
+  ////        here i'm introducing the boundaries for where the AltVal will occur
+  diriBounds.resize(2);
+  if (ppParams.contains("diriBounds"))
+    {
+    std::vector<Real>  temp = std::vector<Real>();
+    ppParams.getarr("diriBounds", temp, 0, 2);
+    diriBounds[0] = temp[0]; diriBounds[1] = temp[1];
+    }
+
+  ////        these are the AltVals
+  parseBCVals("enthalpyAltLoVal", bcAltValEnthalpyLo, required);
+  parseBCVals("enthalpyAltHiVal", bcAltValEnthalpyHi, required);
+
+  ////        recompute bounding energy and enthalpy vars???
+  
+  
+  
 
   //  ParmParse ppBC("bc");
 

--- a/src/MushyLayerParams.cpp
+++ b/src/MushyLayerParams.cpp
@@ -6,15 +6,13 @@
  */
 
 #include "MushyLayerParams.h"
-#include "Logging.H"
 #include "MushyLayerUtils.H"
 #include "PhysBCUtil.H"
-#include "ParmParse.H"
 #include "phaseDiagram.H"
-#include "CH_Timer.H"
 
-// This is for printing out variable names, because c++ doesn't do reflection
-#define SHOW(a) LOG(#a << ": " << (a));
+
+//This is for printing out variable names, because c++ doesn't do reflection
+#define SHOW(a) pout() << #a << ": " << (a) << std::endl
 
 /// Darcy timescale
 string MushyLayerParams::s_DARCY_TIMESCALE = "Darcy";
@@ -34,134 +32,146 @@ string MushyLayerParams::s_ADVECTIVE_VELOCITY_SCALE = "Advective";
 /// Darcy velocity scale
 string MushyLayerParams::s_DARCY_VELOCITY_SCALE = "Darcy";
 
-void MushyLayerParams::printBCs(string bcName, Vector<int> bcTypeLo,
-                                Vector<int> bcTypeHi, RealVect bcValLo,
-                                RealVect bcValHi)
-{
-  char buffer[100];
-  sprintf(buffer, "%-10s", bcName.c_str());
-  LOG_NOEND(buffer);
-
-  Vector<string> bcTypeNames;
-  bcTypeNames.push_back("Fixed");
-  bcTypeNames.push_back("No flux");
-
-  for (int dir = 0; dir < SpaceDim; dir++)
-  {
-    sprintf(buffer, "|%-10s= %02.2f|%-10s= %02.2f",
-            m_scalarBCTypes[bcTypeLo[dir]].c_str(), bcValLo[dir],
-            m_scalarBCTypes[bcTypeHi[dir]].c_str(), bcValHi[dir]);
-    pout() << buffer;
-  }
-  pout() << endl;
-}
-
 // Initialise in initialization list
-MushyLayerParams::MushyLayerParams()
-    : physicalProblem(PhysicalProblems::m_mushyLayer), viscosity(-999),
-      heatConductivityLiquid(-999), heatConductivitySolid(-999),
-      specificHeatLiquid(-999), specificHeatSolid(-999), liquidDensity(-999),
-      latentHeatDissolution(-999), thermalExpansivity(-999),
-      solutalExpansivity(-999), eutecticTemp(-999), eutecticComposition(-999),
-      initialComposition(-999), liquidusSlope(-999),
-      waterDistributionCoeff(-999), heleShawCoolingCoeff(-999),
-      liquidSoluteDiffusivity(-999), d(-999), height(-999), width(-999),
-      referencePermeability(-999), gravitationalAcceleration(-999), V(-999),
-      deltaTemp(-999), deltaSalt(-999), stefan(-999), compositionRatio(-999),
-      liquidHeatDiffusivity(-999), heatConductivityRatio(-999),
-      specificHeatRatio(-999), lewis(-999), darcy(-999),
-      nonDimReluctance(-999.0), heleShawPermeability(-999.0), reynolds(-999),
-      prandtl(0.0), rayleighTemp(-999), rayleighComposition(-999),
-      timescale(-999), m_nondimensionalisation(0), m_heatDiffusionCoeff(1),
-      m_saltDiffusionCoeff(1), activeTracerDiffusionCoeff(0),
-      passiveTracerDiffusionCoeff(0), activeTracerInitVal(0),
-      passiveTracerInitVal(0), m_viscosityCoeff(1), m_buoyancyTCoeff(1.0),
-      m_buoyancySCoeff(1), m_darcyCoeff(1), m_advectionCoeff(1.0),
-      body_force(0.0), nonDimVel(-999), nonDimHeleShawCooling(-999),
-      thetaEutectic(-999), thetaInf(-999), thetaInitialLiquidus(-999),
-      thetaInitial(-999), thetaInterface(-999), ThetaEutectic(-999),
-      ThetaInitial(-999), ThetaInf(-999), ThetaLInitial(-999),
-      ThetaSInitial(-999), Hinitial(-999), thetaPlumeInflow(-999),
-      HPlumeInflow(-999), ThetaPlumeInflow(-999), ThetaLPlumeInflow(-999),
-      ThetaSPlumeInflow(-999), porosityPlume(-999), permeabilityPlume(-999),
-      HLiquidusPlume(-999), HEutecticPlume(-999), HSolidusPlume(-999),
-      referenceTemperature(-999), referenceSalinity(-999), inflowVelocity(-999),
-      pressureHead(0), sinusoidal_temperature_bc_timescale(1),
-      sinusoidal_temperature_bc_amplitude(0.5),
-      sinusoidal_temperature_bc_av(0.5),
-      sinusoidal_temperature_bc_phase_diff(0.0), max_bc_iter(1),
-      bc_nonlinear_solve_method(NonlinearBCSolveMethods::picard),
-      max_bc_residual(3), bc_relax_coeff(0.5), m_BCAccuracy(1),
-      m_pressureBCAccuracy(1), m_time(-999), m_timeDependentBC(m_constant),
-      m_BCamplitude(0), m_BCtimescale(1), fixedTempDirection(-999),
-      permeabilityFunction(PermeabilityFunctions::m_kozenyCarman),
-      heleShaw(false),
-      m_porosityFunction(ParamsPorosityFunctions::m_porosityConstant),
-      m_viscosityFunction(ViscosityFunction::uniformViscosity),
-      max_viscosity(1.0)
-{
-  m_scalarBCTypes.push_back("fixed");
-  m_scalarBCTypes.push_back("noflux");
-  m_scalarBCTypes.push_back("open");
-  m_scalarBCTypes.push_back("inflow");
+MushyLayerParams::MushyLayerParams() : physicalProblem(PhysicalProblems::m_mushyLayer),
+    viscosity(-999),
+    heatConductivityLiquid(-999),
+    heatConductivitySolid(-999 ),
+    specificHeatLiquid(-999 ),
+    specificHeatSolid(-999 ),
+    liquidDensity(-999 ),
+    latentHeatDissolution(-999 ),
+    thermalExpansivity(-999 ),
+    solutalExpansivity(-999 ),
+    eutecticTemp(-999 ),
+    eutecticComposition(-999 ),
+    initialComposition(-999 ),
+    liquidusSlope(-999 ),
+    waterDistributionCoeff(-999 ),
+    heleShawCoolingCoeff(-999 ),
+    liquidSoluteDiffusivity(-999 ),
+    d(-999 ),
+    height(-999 ),
+    width(-999),
+    referencePermeability(-999 ),
+    gravitationalAcceleration(-999 ),
+    V(-999 ),
+    deltaTemp(-999 ),
+    deltaSalt(-999),
+    stefan(-999 ),
+    compositionRatio(-999 ),
+    liquidHeatDiffusivity(-999 ),
+    heatConductivityRatio(-999 ),
+    specificHeatRatio(-999 ),
+    lewis(-999 ),
+    darcy(-999),
+    nonDimReluctance(-999.0),
+    heleShawPermeability(-999.0),
+    reynolds(-999),
+    prandtl(0.0),
+    rayleighTemp(-999 ),
+    rayleighComposition(-999 ),
+    timescale(-999 ),
+    m_nondimensionalisation(0),
+    m_heatDiffusionCoeff(1),
+    m_saltDiffusionCoeff(1),
+    activeTracerDiffusionCoeff(0),
+    passiveTracerDiffusionCoeff(0),
+    activeTracerInitVal(0),
+    passiveTracerInitVal(0),
+    m_viscosityCoeff(1),
+    m_buoyancyTCoeff(1.0),
+    m_buoyancySCoeff(1),
+    m_darcyCoeff(1),
+    m_advectionCoeff(1.0),
+    body_force(0.0),
+    nonDimVel(-999 ),
+    nonDimHeleShawCooling(-999 ),
+    thetaEutectic(-999 ),
+    thetaInf(-999 ),
+    thetaInitialLiquidus(-999 ),
+    thetaInitial(-999 ),
+    thetaInterface(-999 ),
+    ThetaEutectic(-999 ),
+    ThetaInitial(-999 ),
+    ThetaInf(-999 ),
+    ThetaLInitial(-999 ),
+    ThetaSInitial(-999),
+    Hinitial(-999 ),
+    thetaPlumeInflow(-999),
+    HPlumeInflow(-999),
+    ThetaPlumeInflow(-999),
+    ThetaLPlumeInflow(-999),
+    ThetaSPlumeInflow(-999),
+    porosityPlume(-999),
+    permeabilityPlume(-999),
+    HLiquidusPlume(-999),
+    HEutecticPlume(-999),
+    HSolidusPlume(-999),
+    referenceTemperature(-999),
+    referenceSalinity(-999),
+    inflowVelocity(-999),
+    pressureHead(0),
+    sinusoidal_temperature_bc_timescale(1),
+    sinusoidal_temperature_bc_amplitude(0.5),
+    sinusoidal_temperature_bc_av(0.5),
+    sinusoidal_temperature_bc_phase_diff(0.0),
+    max_bc_iter(1),
+    bc_nonlinear_solve_method(NonlinearBCSolveMethods::picard) ,
+    max_bc_residual(3),
+    bc_relax_coeff(0.5),
+    m_BCAccuracy(1),
+    m_pressureBCAccuracy(1),
+    m_time(-999),
+    m_timeDependentBC(m_constant),
+    m_BCamplitude(0),
+    m_BCtimescale(1),
+    fixedTempDirection(-999),
+    permeabilityFunction(PermeabilityFunctions::m_kozenyCarman),
+    heleShaw(false),
+    m_porosityFunction(ParamsPorosityFunctions::m_porosityConstant),
+    m_viscosityFunction(ViscosityFunction::uniformViscosity),
+    max_viscosity(1.0)
+{}
 
-  m_vectorBCTypes.push_back("noflow");
-  m_vectorBCTypes.push_back("inflowVelocity");
-  m_vectorBCTypes.push_back("open");
-  m_vectorBCTypes.push_back("outflownormal");
-  m_vectorBCTypes.push_back("inflowoutflow");
-  m_vectorBCTypes.push_back("noshear");
-  m_vectorBCTypes.push_back("symmetry");
-  m_vectorBCTypes.push_back("inflowPlume");
-  m_vectorBCTypes.push_back("outflowPressureGrad");
-  m_vectorBCTypes.push_back("pressureHead");
+MushyLayerParams::~MushyLayerParams() {
 }
 
-MushyLayerParams::~MushyLayerParams() {}
-
-void MushyLayerParams::computeDerivedBCs()
+void
+MushyLayerParams::computeDerivedBCs ()
 {
-  pout() << "MushyLayerParams::computeDerivedBCs ThetaInitial=" << ThetaInitial
-         << ", H top = " << bcValEnthalpyHi[SpaceDim - 1] << endl;
   // Now do defaults for the other boundary values
-  for (int dir = 0; dir < SpaceDim; dir++)
-  {
-    Real bulkCHi = bcValBulkConcentrationHi[dir];
-    Real bulkCLo = bcValBulkConcentrationLo[dir];
-
-    if (bcTypeBulkConcentrationHi[dir] == PhysBCUtil::Neumann)
-    {
-      bulkCHi = ThetaInitial;
-    }
-
-    if (bcTypeBulkConcentrationLo[dir] == PhysBCUtil::Neumann)
-    {
-      bulkCLo = ThetaInitial;
-    }
-
-    ::computeBoundingEnergy(
-        bcValEnthalpyHi[dir], bulkCHi, bcValSolidusHi[dir],
-        bcValLiquidusHi[dir], bcValEutecticHi[dir], specificHeatRatio, stefan,
-        compositionRatio, waterDistributionCoeff, thetaEutectic, ThetaEutectic);
-    ::computeEnthalpyVars(
-        bcValEnthalpyHi[dir], bulkCHi, bcValPorosityHi[dir],
-        bcValTemperatureHi[dir], bcValLiquidConcentrationHi[dir],
-        bcValSolidConcentrationHi[dir], bcValSolidusHi[dir],
-        bcValLiquidusHi[dir], bcValEutecticHi[dir], specificHeatRatio, stefan,
-        compositionRatio, waterDistributionCoeff, thetaEutectic, ThetaEutectic);
-
-    ::computeBoundingEnergy(
-        bcValEnthalpyLo[dir], bulkCLo, bcValSolidusLo[dir],
-        bcValLiquidusLo[dir], bcValEutecticLo[dir], specificHeatRatio, stefan,
-        compositionRatio, waterDistributionCoeff, thetaEutectic, ThetaEutectic);
-    ::computeEnthalpyVars(
-        bcValEnthalpyLo[dir], bulkCLo, bcValPorosityLo[dir],
-        bcValTemperatureLo[dir], bcValLiquidConcentrationLo[dir],
-        bcValSolidConcentrationLo[dir], bcValSolidusLo[dir],
-        bcValLiquidusLo[dir], bcValEutecticLo[dir], specificHeatRatio, stefan,
-        compositionRatio, waterDistributionCoeff, thetaEutectic, ThetaEutectic);
-    bcValPermeabilityHi[dir] = calculatePermeability(bcValPorosityHi[dir]);
-    bcValPermeabilityLo[dir] = calculatePermeability(bcValPorosityLo[dir]);
+  for (int dir = 0; dir < SpaceDim; dir++) {
+    ::computeBoundingEnergy (bcValEnthalpyHi[dir],
+                             bcValBulkConcentrationHi[dir], bcValSolidusHi[dir],
+                             bcValLiquidusHi[dir], bcValEutecticHi[dir],
+                             specificHeatRatio, stefan, compositionRatio,
+                             waterDistributionCoeff, thetaEutectic,
+                             ThetaEutectic);
+    ::computeEnthalpyVars (bcValEnthalpyHi[dir], bcValBulkConcentrationHi[dir],
+                           bcValPorosityHi[dir], bcValTemperatureHi[dir],
+                           bcValLiquidConcentrationHi[dir],
+                           bcValSolidConcentrationHi[dir], bcValSolidusHi[dir],
+                           bcValLiquidusHi[dir], bcValEutecticHi[dir],
+                           specificHeatRatio, stefan, compositionRatio,
+                           waterDistributionCoeff, thetaEutectic,
+                           ThetaEutectic);
+    ::computeBoundingEnergy (bcValEnthalpyLo[dir],
+                             bcValBulkConcentrationLo[dir], bcValSolidusLo[dir],
+                             bcValLiquidusLo[dir], bcValEutecticLo[dir],
+                             specificHeatRatio, stefan, compositionRatio,
+                             waterDistributionCoeff, thetaEutectic,
+                             ThetaEutectic);
+    ::computeEnthalpyVars (bcValEnthalpyLo[dir], bcValBulkConcentrationLo[dir],
+                           bcValPorosityLo[dir], bcValTemperatureLo[dir],
+                           bcValLiquidConcentrationLo[dir],
+                           bcValSolidConcentrationLo[dir], bcValSolidusLo[dir],
+                           bcValLiquidusLo[dir], bcValEutecticLo[dir],
+                           specificHeatRatio, stefan, compositionRatio,
+                           waterDistributionCoeff, thetaEutectic,
+                           ThetaEutectic);
+    bcValPermeabilityHi[dir] = calculatePermeability (bcValPorosityHi[dir]);
+    bcValPermeabilityLo[dir] = calculatePermeability (bcValPorosityLo[dir]);
 
     if (dir == SpaceDim - 1)
     {
@@ -173,33 +183,10 @@ void MushyLayerParams::computeDerivedBCs()
       else
       {
         Hinitial = bcValEnthalpyLo[dir];
+        ;
       }
     }
   }
-
-  LOG("After computeDerivedBCs: ");
-  LOG_NOEND("         ");
-  Vector<string> direction;
-  direction.push_back("x");
-  direction.push_back("y");
-  direction.push_back("z");
-  for (int dir = 0; dir < SpaceDim; dir++)
-  {
-    pout() << "| " << direction[dir] << "(lo)         | " << direction[dir]
-           << "(hi)         ";
-  }
-  pout() << endl;
-
-  //    printBCs("H", bcTypeEnthalpyLo, bcTypeEnthalpyHi, bcValEnthalpyLo,
-  //    bcValEnthalpyHi); printBCs("C", bcTypeBulkConcentrationLo,
-  //    bcTypeBulkConcentrationHi, bcValBulkConcentrationLo,
-  //    bcValBulkConcentrationHi);
-  printBCs("T", bcTypeTemperatureLo, bcTypeTemperatureHi, bcValTemperatureLo,
-           bcValTemperatureHi);
-  printBCs("Sl", bcTypeLiquidConcentrationLo, bcTypeLiquidConcentrationHi,
-           bcValLiquidConcentrationLo, bcValLiquidConcentrationHi);
-  printBCs("porosity", bcTypePorosityLo, bcTypePorosityHi, bcValPorosityLo,
-           bcValPorosityHi);
 }
 
 void MushyLayerParams::getParameters()
@@ -233,8 +220,7 @@ void MushyLayerParams::getParameters()
 
   ppParams.query("heleShaw", heleShaw);
 
-  // I don't think I necessarily need these, if I'm specifying non dimensional
-  // parameters
+  // I don't think I necessarily need these, if I'm specifying non dimensional parameters
   ppParams.query("viscosity", viscosity);
   ppParams.query("heatConductivityLiquid", heatConductivityLiquid);
   ppParams.query("heatConductivitySolid", heatConductivitySolid);
@@ -270,18 +256,15 @@ void MushyLayerParams::getParameters()
   ppParams.query("fixedTempDirection", fixedTempDirection);
   ppParams.query("inflowVelocity", inflowVelocity);
 
-  ppBC.query("sinusoidal_temperature_bc_timescale",
-             sinusoidal_temperature_bc_timescale);
-  ppBC.query("sinusoidal_temperature_bc_amplitude",
-             sinusoidal_temperature_bc_amplitude);
+
+  ppBC.query("sinusoidal_temperature_bc_timescale", sinusoidal_temperature_bc_timescale);
+  ppBC.query("sinusoidal_temperature_bc_amplitude", sinusoidal_temperature_bc_amplitude);
   ppBC.query("sinusoidal_temperature_bc_av", sinusoidal_temperature_bc_av);
-  ppBC.query("sinusoidal_temperature_bc_phase_diff",
-             sinusoidal_temperature_bc_phase_diff);
+  ppBC.query("sinusoidal_temperature_bc_phase_diff", sinusoidal_temperature_bc_phase_diff);
 
   ppBC.query("timeDependent", m_timeDependentBC);
 
-  // Derived parameters. Can enforce these if needed (e.g. for benchmarking with
-  // a reduced model)
+  //Derived parameters. Can enforce these if needed (e.g. for benchmarking with a reduced model)
   if (ppParams.contains("deltaSalt"))
   {
     ppParams.get("deltaSalt", deltaSalt);
@@ -291,13 +274,14 @@ void MushyLayerParams::getParameters()
     deltaSalt = (eutecticComposition - initialComposition);
   }
 
+
   if (ppParams.contains("deltaTemp"))
   {
     ppParams.get("deltaTemp", deltaTemp);
   }
   else
   {
-    deltaTemp = -liquidusSlope * deltaSalt;
+    deltaTemp = - liquidusSlope * deltaSalt;
   }
 
   if (ppParams.contains("stefan"))
@@ -315,8 +299,7 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    compositionRatio =
-        (1 - waterDistributionCoeff) * eutecticComposition / deltaSalt;
+    compositionRatio = (1-waterDistributionCoeff) * eutecticComposition / deltaSalt;
   }
 
   if (ppParams.contains("liquidHeatDiffusivity"))
@@ -325,8 +308,7 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    liquidHeatDiffusivity =
-        heatConductivityLiquid / (liquidDensity * specificHeatLiquid);
+    liquidHeatDiffusivity = heatConductivityLiquid/(liquidDensity * specificHeatLiquid);
   }
 
   if (ppParams.contains("heatConductivityRatio"))
@@ -335,7 +317,7 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    heatConductivityRatio = heatConductivitySolid / heatConductivityLiquid;
+    heatConductivityRatio = heatConductivitySolid/heatConductivityLiquid;
   }
 
   if (ppParams.contains("specificHeatRatio"))
@@ -344,7 +326,7 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    specificHeatRatio = specificHeatSolid / specificHeatLiquid;
+    specificHeatRatio = specificHeatSolid/specificHeatLiquid;
   }
 
   if (ppParams.contains("lewis"))
@@ -353,7 +335,7 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    lewis = liquidHeatDiffusivity / liquidSoluteDiffusivity;
+    lewis = liquidHeatDiffusivity/liquidSoluteDiffusivity;
   }
 
   if (ppParams.contains("reynolds"))
@@ -362,7 +344,7 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    reynolds = liquidDensity * liquidHeatDiffusivity / viscosity;
+    reynolds = liquidDensity*liquidHeatDiffusivity/viscosity;
   }
 
   if (ppParams.contains("prandtl"))
@@ -371,8 +353,9 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    prandtl = viscosity / liquidDensity * liquidHeatDiffusivity;
+    prandtl = viscosity/liquidDensity*liquidHeatDiffusivity;
   }
+
 
   if (ppParams.contains("darcy"))
   {
@@ -380,17 +363,17 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    darcy = referencePermeability / (height * height);
+    darcy = referencePermeability / (height*height);
   }
 
-  //  if (pp.contains("nonDimReluctance"))
-  //  {
-  //    pp.get("nonDimReluctance", nonDimReluctance);
-  //  }
-  //  else
-  //  {
-  //    nonDimReluctance = referencePermeability*12/(d*d);
-  //  }
+//  if (pp.contains("nonDimReluctance"))
+//  {
+//    pp.get("nonDimReluctance", nonDimReluctance);
+//  }
+//  else
+//  {
+//    nonDimReluctance = referencePermeability*12/(d*d);
+//  }
 
   if (ppParams.contains("heleShawPermeability"))
   {
@@ -398,14 +381,15 @@ void MushyLayerParams::getParameters()
   }
   else if (ppParams.contains("nonDimReluctance"))
   {
-    Real rel = 0.0;
+    Real rel  = 0.0;
     ppParams.get("nonDimReluctance", rel);
-    heleShawPermeability = 1.0 / rel;
+    heleShawPermeability = 1.0/rel;
   }
   else
   {
-    heleShawPermeability = d * d / (12 * referencePermeability);
+    heleShawPermeability = d*d/(12*referencePermeability);
   }
+
 
   if (ppParams.contains("nonDimHeleShawCooling"))
   {
@@ -413,8 +397,7 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    nonDimHeleShawCooling =
-        heleShawCoolingCoeff * (height * height) / heatConductivityLiquid;
+    nonDimHeleShawCooling = heleShawCoolingCoeff * (height*height)/heatConductivityLiquid;
   }
 
   if (ppParams.contains("rayleighTemp"))
@@ -423,9 +406,8 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    rayleighTemp = thermalExpansivity * liquidDensity *
-                   gravitationalAcceleration * height * deltaTemp *
-                   referencePermeability / (liquidHeatDiffusivity * viscosity);
+    rayleighTemp = thermalExpansivity*liquidDensity*gravitationalAcceleration*height*
+        deltaTemp*referencePermeability / (liquidHeatDiffusivity*viscosity);
   }
 
   if (ppParams.contains("rayleighComp"))
@@ -434,13 +416,12 @@ void MushyLayerParams::getParameters()
   }
   else
   {
-    rayleighComposition = solutalExpansivity * liquidDensity *
-                          gravitationalAcceleration * height * deltaSalt *
-                          referencePermeability /
-                          (liquidHeatDiffusivity * viscosity);
+    rayleighComposition = solutalExpansivity*liquidDensity*gravitationalAcceleration*height*
+        deltaSalt*referencePermeability /
+        (liquidHeatDiffusivity*viscosity);
   }
 
-  timescale = height * height / liquidHeatDiffusivity;
+  timescale = height*height/liquidHeatDiffusivity;
 
   // Optional parameters
   //  bottomTemp = -999;
@@ -448,14 +429,15 @@ void MushyLayerParams::getParameters()
   //  pp.query("bottomTemp", bottomTemp);
   //  pp.query("topTemp", topTemp);
 
-  // Some nondimensional parameters and boundary conditions
+
+  //Some nondimensional parameters and boundary conditions
   if (ppParams.contains("nonDimVel"))
   {
     ppParams.get("nonDimVel", nonDimVel);
   }
   else
   {
-    //    nonDimVel = (height/liquidHeatDiffusivity) * V;
+//    nonDimVel = (height/liquidHeatDiffusivity) * V;
     nonDimVel = 0.0;
   }
 
@@ -483,44 +465,46 @@ void MushyLayerParams::getParameters()
   plumeBounds.resize(2);
   if (ppParams.contains("plumeBounds"))
   {
-    std::vector<Real> temp = std::vector<Real>();
+    std::vector<Real>  temp = std::vector<Real>();
     ppParams.getarr("plumeBounds", temp, 0, 2);
     //    for (int dir=0; dir<SpaceDim; dir++)
     //    {
     //      plumeBounds[dir] = temp[dir];
     //    }
-    plumeBounds[0] = temp[0];
-    plumeBounds[1] = temp[1];
+    plumeBounds[0] = temp[0]; plumeBounds[1] = temp[1];
   }
+
 
   ppParams.query("enthalpyPlume", HPlumeInflow);
   ppParams.query("bulkConcPlume", ThetaPlumeInflow);
-  
-  
-  
-  
-  //// jb - attempting to add multiple dirichlet BC values option for Enthalpy (maybe Salinity in future)
-  ////    - currently keeping things in one spot, can redistribute after they're checked
-  
-  ////        here i'm introducing the boundaries for where the AltVal will occur
-  diriBounds.resize(2);
-  if (ppParams.contains("diriBounds"))
+
+
+    //// jb - attempting to add multiple dirichlet BC values option for Enthalpy (maybe Salinity in future)
+    ////    - currently keeping things in one spot, can redistribute after they're checked
+
+    ////        here i'm introducing the boundaries for where the AltVal will occur
+    // diriSwitch.resize(2);
+
+    if (ppParams.contains("diriSwitch"))
     {
-    std::vector<Real>  temp = std::vector<Real>();
-    ppParams.getarr("diriBounds", temp, 0, 2);
-    diriBounds[0] = temp[0]; diriBounds[1] = temp[1];
+        //std::vector<Real>  temp = std::vector<Real>();
+        //ppParams.getarr("diriBounds", temp, 0, 2);
+        //diriBounds[0] = temp[0]; diriBounds[1] = temp[1];
+        parseBCVals("diriSwitchLo", bcDiriSwitchLo);
+        parseBCVals("diriSwitchHi", bcDiriSwitchHi);
+        //ppParams.query("diriSwitchLo", diriSwitchLo);
+        //ppParams.query("diriSwitchHi", diriSwitchHi);
     }
 
-  ////        these are the AltVals
-  parseBCVals("enthalpyAltLoVal", bcAltValEnthalpyLo, required);
-  parseBCVals("enthalpyAltHiVal", bcAltValEnthalpyHi, required);
+    ////        these are the AltVals
+    parseBCVals("temperatureAltValLo", bcAltValTemperatureLo);
+    parseBCVals("temperatureAltValHi", bcAltValTemperatureHi);
+    //parseBCVals("enthalpyAltHiVal", bcAltValEnthalpyHi, required);
 
-  ////        recompute bounding energy and enthalpy vars???
-  
-  
-  
+    ////        recompute bounding energy and enthalpy vars???
 
-  //  ParmParse ppBC("bc");
+
+//  ParmParse ppBC("bc");
 
   // Define BC objects
   bcTypeVelLo.resize(SpaceDim, PhysBCUtil::SolidWall);
@@ -562,33 +546,31 @@ void MushyLayerParams::getParameters()
   parseBCs("velHi", &bcTypeVelHi, required);
 
   // By default, set enthalpy and bulk conc to be the same as scalar bcs
-  for (int dir = 0; dir < SpaceDim; dir++)
+  for (int dir=0; dir<SpaceDim; dir++)
   {
     bcTypeBulkConcentrationLo[dir] = bcTypeScalarLo[dir];
-    bcTypeBulkConcentrationHi[dir] = bcTypeScalarHi[dir];
+    bcTypeBulkConcentrationHi[dir] =  bcTypeScalarHi[dir];
     bcTypeEnthalpyLo[dir] = bcTypeScalarLo[dir];
-    bcTypeEnthalpyHi[dir] = bcTypeScalarHi[dir];
+    bcTypeEnthalpyHi[dir] =  bcTypeScalarHi[dir];
 
     bcTypeLiquidConcentrationLo[dir] = bcTypeScalarLo[dir];
-    bcTypeLiquidConcentrationHi[dir] = bcTypeScalarHi[dir];
+    bcTypeLiquidConcentrationHi[dir] =  bcTypeScalarHi[dir];
     bcTypeTemperatureLo[dir] = bcTypeScalarLo[dir];
-    bcTypeTemperatureHi[dir] = bcTypeScalarHi[dir];
+    bcTypeTemperatureHi[dir] =  bcTypeScalarHi[dir];
   }
 
-  // Porosity is slightly different - by defualt, want fixed porosity at top and
-  // bottom (already set) and neumann conditions at sides
+  // Porosity is slightly different - by defualt, want fixed porosity at top and bottom (already set) and neumann conditions at sides
   bcTypePorosityLo[0] = PhysBCUtil::Neumann;
   bcTypePorosityHi[0] = PhysBCUtil::Neumann;
   bcTypePermeabilityLo[0] = PhysBCUtil::Neumann;
   bcTypePermeabilityHi[0] = PhysBCUtil::Neumann;
 
+
   // BC values. User must specify H, C and velocity as a minimum
-  // If we have specified any options in our param files, overwrite defaults
-  // with them
+  // If we have specified any options in our param files, overwrite defaults with them
 
   //
-  // Optional extra BCs, if not specified, these are computed from the H and C
-  // already provided
+  // Optional extra BCs, if not specified, these are computed from the H and C already provided
 
   parseBCs("enthalpyLo", &bcTypeEnthalpyLo);
   parseBCs("enthalpyHi", &bcTypeEnthalpyHi);
@@ -617,7 +599,8 @@ void MushyLayerParams::getParameters()
   parseBCVals("bulkConcentrationLoVal", bcValBulkConcentrationLo, required);
   parseBCVals("bulkConcentrationHiVal", bcValBulkConcentrationHi, required);
 
-  for (int dir = 0; dir < SpaceDim; dir++)
+
+  for (int dir=0; dir < SpaceDim; dir++)
   {
     bcValPressureHi[dir] = 0.0;
     bcValPressureLo[dir] = 0.0;
@@ -627,8 +610,8 @@ void MushyLayerParams::getParameters()
   if (ppParams.contains("pressureHead"))
   {
     ppParams.query("pressureHead", pressureHead);
-    bcValPressureHi[SpaceDim - 1] = pressureHead;
-    bcValPressureLo[SpaceDim - 1] = 0.0;
+    bcValPressureHi[SpaceDim-1] = pressureHead;
+    bcValPressureLo[SpaceDim-1] = 0.0;
   }
 
   parseBCVals("bcValPressureHi", bcValPressureHi);
@@ -643,7 +626,7 @@ void MushyLayerParams::getParameters()
   max_bc_iter = 2;
   ppMain.query("max_bc_iter", max_bc_iter);
 
-  max_bc_residual = 1e-5;
+  max_bc_residual= 1e-5;
   ppMain.query("max_bc_residual", max_bc_residual);
 
   bc_relax_coeff = 0.5;
@@ -652,22 +635,25 @@ void MushyLayerParams::getParameters()
   bc_nonlinear_solve_method = NonlinearBCSolveMethods::picard;
   ppMain.query("nonlinear_bc_solve_method", bc_nonlinear_solve_method);
 
+
   // For the plume
-  ::computeBoundingEnergy(HPlumeInflow, ThetaPlumeInflow, HSolidusPlume,
-                          HLiquidusPlume, HEutecticPlume, specificHeatRatio,
-                          stefan, compositionRatio, waterDistributionCoeff,
+  ::computeBoundingEnergy(HPlumeInflow, ThetaPlumeInflow, HSolidusPlume, HLiquidusPlume, HEutecticPlume,
+                          specificHeatRatio, stefan, compositionRatio, waterDistributionCoeff,
                           thetaEutectic, ThetaEutectic);
-  ::computeEnthalpyVars(HPlumeInflow, ThetaPlumeInflow, porosityPlume,
-                        thetaPlumeInflow, ThetaLPlumeInflow, ThetaSPlumeInflow,
+  ::computeEnthalpyVars(HPlumeInflow, ThetaPlumeInflow, porosityPlume, thetaPlumeInflow,
+                        ThetaLPlumeInflow, ThetaSPlumeInflow,
                         HSolidusPlume, HLiquidusPlume, HEutecticPlume,
-                        specificHeatRatio, stefan, compositionRatio,
-                        waterDistributionCoeff, thetaEutectic, ThetaEutectic);
+                        specificHeatRatio, stefan, compositionRatio, waterDistributionCoeff,
+                        thetaEutectic, ThetaEutectic);
   permeabilityPlume = this->calculatePermeability(porosityPlume);
+
 
   // Now do defaults for the other boundary values
   computeDerivedBCs();
 
+
   // Now BC values
+
   parseBCVals("liquidConcentrationLoVal", bcValLiquidConcentrationLo);
   parseBCVals("liquidConcentrationHiVal", bcValLiquidConcentrationHi);
 
@@ -688,24 +674,30 @@ void MushyLayerParams::getParameters()
     bcTypeVelHi[0] = PhysBCUtil::Outflow;
     bcTypeVelHi[1] = PhysBCUtil::Inflow;
 
-    bcTypeVelLo[0] = PhysBCUtil::noShear;
-    bcTypeVelLo[1] = PhysBCUtil::noShear;
+    bcTypeVelLo[0]  =PhysBCUtil::noShear;
+    bcTypeVelLo[1]  =PhysBCUtil::noShear;
+
+
   }
-  else if (physicalProblem == m_mushyLayer)
+  else if (physicalProblem == m_mushyLayer )
   {
+
+
+
   }
 
+
+
   // Now sort out nondimensionalisation
-  if (!isDarcyBrinkman() &&
-      m_nondimensionalisation != m_diffusiveTime_advectiveVel)
+  if (!isDarcyBrinkman()
+      && m_nondimensionalisation != m_diffusiveTime_advectiveVel)
   {
-    MayDay::Error("Need to choose diffusive timescale/advection velocity scale "
-                  "for solving Darcy flow.");
+    MayDay::Error("Need to choose diffusive timescale/advection velocity scale for solving Darcy flow.");
   }
 
   if (m_nondimensionalisation == m_darcyTime_advectiveVel)
   {
-    LOG("Darcy timescale, advective velocity scale");
+    pout() << "Darcy timescale, advective velocity scale" << endl;
 
     // To avoid dividing by 0 when Da = Pr = 0
     if (darcy == prandtl)
@@ -714,26 +706,28 @@ void MushyLayerParams::getParameters()
     }
     else
     {
-      m_heatDiffusionCoeff = darcy / prandtl;
+      m_heatDiffusionCoeff = darcy/prandtl;
     }
-    m_saltDiffusionCoeff = m_heatDiffusionCoeff / lewis;
+    m_saltDiffusionCoeff = m_heatDiffusionCoeff/lewis;
     m_viscosityCoeff = darcy;
 
-    m_buoyancyTCoeff = rayleighTemp * darcy * darcy * prandtl;
-    m_buoyancySCoeff = rayleighComposition * darcy * darcy * prandtl;
+    m_buoyancyTCoeff = rayleighTemp*darcy*darcy*prandtl;
+    m_buoyancySCoeff = rayleighComposition*darcy*darcy*prandtl;
     m_darcyCoeff = 1.0;
     m_advectionCoeff = 1.0;
+
+
   }
   else if (m_nondimensionalisation == m_diffusiveTime_advectiveVel)
   {
-    LOG("Diffusive timescale, advective velocity scale");
+    pout() << "Diffusive timescale, advective velocity scale" << endl;
 
     m_heatDiffusionCoeff = 1.0;
-    m_saltDiffusionCoeff = 1 / lewis;
+    m_saltDiffusionCoeff = 1/lewis;
     m_viscosityCoeff = prandtl;
-    m_buoyancyTCoeff = prandtl * rayleighTemp;
-    m_buoyancySCoeff = prandtl * rayleighComposition;
-    m_darcyCoeff = prandtl / darcy;
+    m_buoyancyTCoeff = prandtl*rayleighTemp;
+    m_buoyancySCoeff = prandtl*rayleighComposition;
+    m_darcyCoeff = prandtl/darcy;
     m_advectionCoeff = 1.0;
 
     if (!isDarcyBrinkman())
@@ -745,78 +739,77 @@ void MushyLayerParams::getParameters()
   else if (m_nondimensionalisation == m_darcyTime_darcyVel)
   {
 
-    LOG("Darcy timescale, darcy velocity scale");
+    pout() << "Darcy timescale, darcy velocity scale" << endl;
 
-    m_heatDiffusionCoeff = darcy / prandtl;
-    m_saltDiffusionCoeff = m_heatDiffusionCoeff / lewis;
+
+    m_heatDiffusionCoeff = darcy/prandtl;
+    m_saltDiffusionCoeff = m_heatDiffusionCoeff/lewis;
     m_viscosityCoeff = darcy;
-    m_buoyancyTCoeff = 1.0; // rayleighTemp*darcy*darcy*prandtl;
-    m_buoyancySCoeff = rayleighComposition /
-                       rayleighTemp; // rayleighComposition*darcy*darcy*prandtl;
+    m_buoyancyTCoeff = 1.0; //rayleighTemp*darcy*darcy*prandtl;
+    m_buoyancySCoeff = rayleighComposition/rayleighTemp; //rayleighComposition*darcy*darcy*prandtl;
     m_darcyCoeff = 1.0;
-    m_advectionCoeff = rayleighTemp * darcy * darcy / prandtl;
+    m_advectionCoeff = rayleighTemp*darcy*darcy/prandtl;
   }
   else if (m_nondimensionalisation == m_advectiveTime_darcyVel)
   {
-    LOG("Advective timescale, darcy velocity scale");
+    pout() << "Advective timescale, darcy velocity scale" << endl;
 
-    m_heatDiffusionCoeff = 1 / (darcy * rayleighTemp);
-    m_saltDiffusionCoeff = m_heatDiffusionCoeff / lewis;
-    m_viscosityCoeff = prandtl / (darcy * rayleighTemp);
-    m_buoyancyTCoeff = prandtl / (darcy * rayleighTemp);
-    m_buoyancySCoeff = m_buoyancyTCoeff * (rayleighComposition / rayleighTemp);
-    m_darcyCoeff = prandtl / (darcy * darcy * rayleighTemp);
+    m_heatDiffusionCoeff = 1/(darcy*rayleighTemp);
+    m_saltDiffusionCoeff = m_heatDiffusionCoeff/lewis;
+    m_viscosityCoeff = prandtl/(darcy*rayleighTemp);
+    m_buoyancyTCoeff = prandtl/(darcy*rayleighTemp);
+    m_buoyancySCoeff = m_buoyancyTCoeff*(rayleighComposition/rayleighTemp);
+    m_darcyCoeff = prandtl/(darcy*darcy*rayleighTemp);
     m_advectionCoeff = 1.0;
   }
   else if (m_nondimensionalisation == m_buoyancyTime_advectiveVel)
   {
-    LOG("Buoyancy timescale, advective velocity scale");
+    pout() << "Buoyancy timescale, advective velocity scale" << endl;
 
     Real R = rayleighComposition;
     if (R == 0)
     {
       if (rayleighTemp == 0)
       {
-        MayDay::Error("MushyLayerParams - Can't nondimensionalise with "
-                      "buoyancy timescale if RaT=RaC=0!!");
+        MayDay::Error("MushyLayerParams - Can't nondimensionalise with buoyancy timescale if RaT=RaC=0!!");
       }
       R = rayleighTemp;
     }
 
-    m_heatDiffusionCoeff = 1 / sqrt(R * prandtl);
-    m_saltDiffusionCoeff = m_heatDiffusionCoeff / lewis;
+    m_heatDiffusionCoeff = 1/sqrt(R*prandtl);
+    m_saltDiffusionCoeff = m_heatDiffusionCoeff/lewis;
 
-    m_viscosityCoeff = sqrt(prandtl / R);
+    m_viscosityCoeff = sqrt(prandtl/R);
 
-    m_darcyCoeff = (1 / darcy) * sqrt(prandtl / R);
+    m_darcyCoeff = (1/darcy)*sqrt(prandtl/R);
     m_advectionCoeff = 1.0;
 
     // Avoid dividing by zero
     if (rayleighComposition != 0)
     {
       m_buoyancySCoeff = 1;
-      m_buoyancyTCoeff = rayleighTemp / rayleighComposition;
+      m_buoyancyTCoeff = rayleighTemp/rayleighComposition;
     }
     else
     {
       m_buoyancySCoeff = 0;
       m_buoyancyTCoeff = 1;
     }
+
   }
   else
   {
     MayDay::Error("Unknown non dimensionalisation");
   }
 
-  // Finally, option to manually set certain terms if we want (for testing
-  // purposes)
-  ppMain.query("heatDiffusionCoeff", m_heatDiffusionCoeff);
-  ppMain.query("saltDiffusionCoeff", m_saltDiffusionCoeff);
-  ppMain.query("viscosityCoeff", m_viscosityCoeff);
-  ppMain.query("buoyancyTCoeff", m_buoyancyTCoeff);
+  // Finally, option to manually set certain terms if we want (for testing purposes)
+  ppMain.query("heatDiffusionCoeff", m_heatDiffusionCoeff );
+  ppMain.query("saltDiffusionCoeff",  m_saltDiffusionCoeff);
+  ppMain.query("viscosityCoeff", m_viscosityCoeff );
+  ppMain.query("buoyancyTCoeff", m_buoyancyTCoeff );
   ppMain.query("buoyancySCoeff", m_buoyancySCoeff);
-  ppMain.query("darcyCoeff", m_darcyCoeff);
-  ppMain.query("advectionCoeff", m_advectionCoeff);
+  ppMain.query("darcyCoeff",  m_darcyCoeff );
+  ppMain.query("advectionCoeff",  m_advectionCoeff );
 
   ppBio.query("activeTracerDiffusionCoeff", activeTracerDiffusionCoeff);
   ppBio.query("passiveTracerDiffusionCoeff", passiveTracerDiffusionCoeff);
@@ -826,37 +819,12 @@ void MushyLayerParams::getParameters()
 
   // uncomment to print the parameters
   //  printParameters();
-
-  LOG("BCs used: ");
-  LOG_NOEND("         ");
-  Vector<string> direction;
-  direction.push_back("x");
-  direction.push_back("y");
-  direction.push_back("z");
-  for (int dir = 0; dir < SpaceDim; dir++)
-  {
-    pout() << "| " << direction[dir] << "(lo)         | " << direction[dir]
-           << "(hi)         ";
-  }
-  pout() << endl;
-
-  printBCs("H", bcTypeEnthalpyLo, bcTypeEnthalpyHi, bcValEnthalpyLo,
-           bcValEnthalpyHi);
-  printBCs("C", bcTypeBulkConcentrationLo, bcTypeBulkConcentrationHi,
-           bcValBulkConcentrationLo, bcValBulkConcentrationHi);
-  printBCs("T", bcTypeTemperatureLo, bcTypeTemperatureHi, bcValTemperatureLo,
-           bcValTemperatureHi);
-  printBCs("Sl", bcTypeLiquidConcentrationLo, bcTypeLiquidConcentrationHi,
-           bcValLiquidConcentrationLo, bcValLiquidConcentrationHi);
-  printBCs("porosity", bcTypePorosityLo, bcTypePorosityHi, bcValPorosityLo,
-           bcValPorosityHi);
 }
 
-void MushyLayerParams::parseBCs(string a_name, Vector<int> *a_bcHolder,
-                                bool required)
+void MushyLayerParams::parseBCs(string a_name, Vector<int>* a_bcHolder, bool required)
 {
-  std::vector<int> temp = std::vector<int>();
-  std::vector<string> temp_str = std::vector<string>();
+  std::vector<int>  temp = std::vector<int>();
+  std::vector<string>  temp_str = std::vector<string>();
   ParmParse ppBC("bc");
 
   if (ppBC.contains(a_name))
@@ -876,7 +844,7 @@ void MushyLayerParams::parseBCs(string a_name, Vector<int> *a_bcHolder,
       temp.resize(temp_str.size());
 
       // Convert strings to numbers
-      for (int idir = 0; idir < SpaceDim; idir++)
+      for (int idir=0; idir<SpaceDim; idir++)
       {
         if (temp_str[idir] == "noflux")
         {
@@ -953,16 +921,17 @@ void MushyLayerParams::parseBCs(string a_name, Vector<int> *a_bcHolder,
 
         else
         {
-          LOG("Unknown BC " << temp_str[idir]);
+          pout() << "Unknown BC " << temp_str[idir] << endl;
           temp[idir] = 0;
         }
       }
     }
 
-    for (int idir = 0; idir < SpaceDim; idir++)
+
+    for (int idir=0; idir<SpaceDim; idir++)
     {
       // We're parsing bc types here, so the values should be >= 0
-      if (temp[idir] != -1)
+      if (temp[idir] !=-1)
       {
         (*a_bcHolder)[idir] = temp[idir];
       }
@@ -972,23 +941,22 @@ void MushyLayerParams::parseBCs(string a_name, Vector<int> *a_bcHolder,
   {
     if (required)
     {
-      LOG("Can't find BC " << a_name);
+      pout() << "Can't find BC " << a_name << endl;
       MayDay::Error("Couldn't find BC");
     }
   }
 }
 
-void MushyLayerParams::parseBCVals(string a_name, RealVect &a_bcHolder,
-                                   bool required)
+void MushyLayerParams::parseBCVals(string a_name, RealVect& a_bcHolder, bool required)
 {
-  std::vector<Real> temp = std::vector<Real>();
+  std::vector<Real>  temp = std::vector<Real>();
   ParmParse ppBC("bc");
 
   if (ppBC.contains(a_name))
   {
     ppBC.getarr(a_name.c_str(), temp, 0, SpaceDim);
 
-    for (int idir = 0; idir < SpaceDim; idir++)
+    for (int idir=0; idir<SpaceDim; idir++)
     {
       a_bcHolder[idir] = temp[idir];
     }
@@ -997,13 +965,16 @@ void MushyLayerParams::parseBCVals(string a_name, RealVect &a_bcHolder,
   {
     if (required)
     {
-      LOG("Can't find BC " << a_name);
+      pout() << "Can't find BC " << a_name << endl;
       MayDay::Error("Couldn't find BC");
     }
   }
 }
 
-bool MushyLayerParams::isViscous() { return (m_viscosityCoeff > 0); }
+bool MushyLayerParams::isViscous()
+{
+  return (m_viscosityCoeff > 0);
+}
 
 bool MushyLayerParams::isDarcyBrinkman()
 {
@@ -1017,47 +988,48 @@ bool MushyLayerParams::isDarcyBrinkman()
   }
 }
 
-void MushyLayerParams::setTime(Real a_time) { m_time = a_time; }
+void MushyLayerParams::setTime(Real a_time)
+{
+  m_time = a_time;
+
+
+}
+
 
 Real MushyLayerParams::calculatePermeability(Real liquidFraction)
 {
   Real permeability = -1.0;
-  Real solidFraction = 1 - liquidFraction;
+  Real solidFraction = 1-liquidFraction;
   //    Real referencePerm = params.referencePermeability;
 
   if (permeabilityFunction == PermeabilityFunctions::m_pureFluid)
   {
     permeability = 1;
   }
-  else if (permeabilityFunction ==
-           PermeabilityFunctions::m_cubicPermeability)
+  else if (permeabilityFunction == PermeabilityFunctions::m_cubicPermeability)
   {
-    permeability = pow(liquidFraction, 3);
+    permeability = pow(liquidFraction,3);
   }
   else if (permeabilityFunction == PermeabilityFunctions::m_kozenyCarman)
   {
-    permeability = pow(liquidFraction, 3) / pow(solidFraction, 2);
+    permeability = pow(liquidFraction,3) / pow(solidFraction,2);
   }
-  else if (permeabilityFunction == PermeabilityFunctions::m_logPermeability)
+  else if(permeabilityFunction == PermeabilityFunctions::m_logPermeability)
   {
-    permeability = -pow(liquidFraction, 2) * log(solidFraction);
+    permeability = - pow(liquidFraction,2) * log(solidFraction);
   }
-  else if (permeabilityFunction ==
-           PermeabilityFunctions::m_porosityPermeability)
+  else if(permeabilityFunction == PermeabilityFunctions::m_porosityPermeability)
   {
     permeability = liquidFraction;
   }
-  else if (permeabilityFunction ==
-           PermeabilityFunctions::m_permeabilityXSquared)
+  else if(permeabilityFunction == PermeabilityFunctions::m_permeabilityXSquared)
   {
-    MayDay::Error(
-        "Can't calculate permeability for x^2 from just the porosity");
+    MayDay::Error("Can't calculate permeability for x^2 from just the porosity");
   }
   else
   {
     permeability = -1;
-    MayDay::Error("amrMushyLayer::calculatePermeability() - Unknown "
-                  "permeability function");
+    MayDay::Error("amrMushyLayer::calculatePermeability() - Unknown permeability function");
   }
 
   Real finalPermeability = permeability;
@@ -1068,9 +1040,9 @@ Real MushyLayerParams::calculatePermeability(Real liquidFraction)
     // Want to take harmonic mean of cell permeability and this permeability
 
     //    Real nonDimCellPerm = d*d / (12 * darcy * height*height);
-    //    Real nonDimCellPerm = 1/nonDimReluctance; // = d*d/(12*K_0)
+//    Real nonDimCellPerm = 1/nonDimReluctance; // = d*d/(12*K_0)
 
-    finalPermeability = 1 / (1 / heleShawPermeability + 1 / permeability);
+    finalPermeability = 1 / (1/heleShawPermeability + 1/permeability);
   }
 
   // Place a cap on the minimum permeability allowed to avoid dividing by 0
@@ -1078,38 +1050,37 @@ Real MushyLayerParams::calculatePermeability(Real liquidFraction)
   //  finalPermeability = Max(finalPermeability, minPermAllowed);
 
   return finalPermeability;
+
 }
 
-Real MushyLayerParams::directionalSolidificationMushyZ(Real theta,
-                                                       Real zEutectic)
+Real MushyLayerParams::
+directionalSolidificationMushyZ(Real theta, Real zEutectic)
 {
-  // Catch a few special situations
+  //Catch a few special situations
   if (stefan == 0)
   {
-    // No mushy layer
+    //No mushy layer
     return zEutectic;
   }
 
-  Real A = 0.5 * (compositionRatio + thetaInf + stefan);
-  Real B = sqrt(A * A - compositionRatio * thetaInf - stefan);
-  Real alpha = A + B;
-  Real beta = A - B;
+  Real A = 0.5*(compositionRatio + thetaInf + stefan);
+  Real B = sqrt(A*A - compositionRatio * thetaInf - stefan);
+  Real alpha = A+B;
+  Real beta = A-B;
 
-  Real vel = nonDimVel / this->m_heatDiffusionCoeff;
+  Real vel = nonDimVel/this->m_heatDiffusionCoeff;
 
-  Real z =
-      zEutectic - (1 / vel) * (((alpha - compositionRatio) / (alpha - beta)) *
-                                   log((alpha) / (alpha - theta)) +
-                               ((compositionRatio - beta) / (alpha - beta)) *
-                                   log((beta) / (beta - theta)));
+  Real z =  zEutectic - (1/vel) * (  ((alpha - compositionRatio) / (alpha-beta)) * log((alpha)/(alpha - theta)) +
+      ((compositionRatio - beta)  / (alpha-beta)) * log((beta) /(beta - theta))        );
 
   return z;
 }
 
-void MushyLayerParams::printParameters()
+void MushyLayerParams::
+printParameters()
 {
 
-  LOG("Parameters: ");
+  pout() << "Parameters: " << endl;
 
   SHOW(physicalProblem);
   SHOW(viscosity);
@@ -1122,8 +1093,8 @@ void MushyLayerParams::printParameters()
   SHOW(thermalExpansivity);
   SHOW(solutalExpansivity);
   SHOW(eutecticTemp);
-  //  SHOW(bottomTemp);
-  //  SHOW(topTemp);
+//  SHOW(bottomTemp);
+//  SHOW(topTemp);
   SHOW(eutecticComposition);
   SHOW(initialComposition);
   SHOW(liquidusSlope);
@@ -1148,7 +1119,7 @@ void MushyLayerParams::printParameters()
   SHOW(nonDimVel);
   SHOW(nonDimHeleShawCooling);
   SHOW(timescale);
-  //  SHOW(nonDimReluctance);
+//  SHOW(nonDimReluctance);
   SHOW(heleShawPermeability);
 
   SHOW(thetaEutectic);
@@ -1156,26 +1127,27 @@ void MushyLayerParams::printParameters()
   SHOW(thetaInitialLiquidus);
   SHOW(thetaInitial);
   SHOW(thetaInterface);
-  //  SHOW(thetaBottom);
-  //  SHOW(thetaTop);
+//  SHOW(thetaBottom);
+//  SHOW(thetaTop);
   SHOW(ThetaEutectic);
   SHOW(ThetaInitial);
   SHOW(ThetaInf);
-  //  SHOW(ThetaTop);
-  //  SHOW(ThetaBottom);
-  //  SHOW(ThetaLBottom);
+//  SHOW(ThetaTop);
+//  SHOW(ThetaBottom);
+//  SHOW(ThetaLBottom);
   SHOW(ThetaLInitial);
-  //  SHOW(ThetaLTop);
-  //  SHOW(porosityTop);
-  //  SHOW(porosityBottom);
-  //  SHOW(HBottom);
-  //  SHOW(HTop);
+//  SHOW(ThetaLTop);
+//  SHOW(porosityTop);
+//  SHOW(porosityBottom);
+//  SHOW(HBottom);
+//  SHOW(HTop);
   SHOW(Hinitial);
 }
 
 Real MushyLayerParams::concToTheta(const Real C)
 {
-  Real Theta = (C - referenceSalinity) / deltaSalt;
+  Real Theta = (C - referenceSalinity) /
+      deltaSalt;
   return Theta;
 }
 
@@ -1184,6 +1156,8 @@ Real MushyLayerParams::tempTotheta(const Real T)
   Real theta = (T - referenceTemperature) / deltaTemp;
   return theta;
 }
+
+
 
 int MushyLayerParams::getVelBCType(int dir, Side::LoHiSide side)
 {
@@ -1202,7 +1176,8 @@ int MushyLayerParams::getVelBCType(int dir, Side::LoHiSide side)
   return bcType;
 }
 
-void MushyLayerParams::writeToHDF5(HDF5HeaderData &a_header) const
+
+void MushyLayerParams::writeToHDF5(HDF5HeaderData& a_header) const
 {
   a_header.m_real["C"] = compositionRatio;
   a_header.m_real["k"] = heatConductivityRatio;
@@ -1219,31 +1194,33 @@ string MushyLayerParams::getTimescale() const
 {
   switch (m_nondimensionalisation)
   {
-  case m_advectiveTime_darcyVel:
-    return s_ADVECTIVE_TIMESCALE;
-    break;
+    case m_advectiveTime_darcyVel:
+      return s_ADVECTIVE_TIMESCALE;
+      break;
 
-  case m_diffusiveTime_advectiveVel:
-    return s_DIFFUSIVE_TIMESCALE;
-    break;
+    case m_diffusiveTime_advectiveVel:
+      return s_DIFFUSIVE_TIMESCALE;
+      break;
 
-  case m_darcyTime_advectiveVel:
-    return s_DARCY_TIMESCALE;
-    break;
+    case     m_darcyTime_advectiveVel:
+      return s_DARCY_TIMESCALE;
+      break;
 
-  case m_darcyTime_darcyVel:
-    return s_DARCY_TIMESCALE;
-    break;
+    case  m_darcyTime_darcyVel:
+      return s_DARCY_TIMESCALE;
+      break;
 
-  case m_buoyancyTime_advectiveVel:
-    return s_BUOYANCY_TIMESCALE;
-    break;
+    case  m_buoyancyTime_advectiveVel:
+      return s_BUOYANCY_TIMESCALE;
+      break;
 
-  default:
-    MayDay::Error("Unknown nondimensionalisation");
-    return "";
-    break;
+    default:
+      MayDay::Error("Unknown nondimensionalisation");
+      return "";
+      break;
+
   }
+
 }
 
 // Utility function
@@ -1251,9 +1228,9 @@ Real MushyLayerParams::computePorosity(Real H, Real C)
 {
   CH_TIME("MushyLayerParams::computePorosity");
 
-  Real porosity = ::computePorosity(
-      H, C, compositionRatio, specificHeatRatio, stefan, waterDistributionCoeff,
-      specificHeatRatio, thetaEutectic, ThetaEutectic);
+  Real porosity = ::computePorosity(H, C, compositionRatio,  specificHeatRatio,
+                                  stefan,  waterDistributionCoeff,  specificHeatRatio,
+                                  thetaEutectic,  ThetaEutectic);
 
   return porosity;
 }
@@ -1265,91 +1242,88 @@ Real MushyLayerParams::compute_dHdT(Real H, Real C)
   H_s = std::nan("1");
   H_l = std::nan("1");
 
-  ::computeBoundingEnergy(H_e, C, H_s, H_l, H_e, specificHeatRatio, stefan,
-                          compositionRatio, waterDistributionCoeff,
-                          thetaEutectic, ThetaEutectic);
+
+  ::computeBoundingEnergy(H_e, C, H_s, H_l, H_e, specificHeatRatio, stefan, compositionRatio, waterDistributionCoeff, thetaEutectic, ThetaEutectic);
 
   if (H <= H_s)
-  {
-    dHdT = 1 / specificHeatRatio;
-  }
-  else if (H > H_s && H <= H_e)
-  {
-    dHdT = 0;
-  }
-  else if (H > H_e && H < H_l)
-  {
-    Real porosity =
-        computePorosityMushyLayer(H, C, compositionRatio, specificHeatRatio,
-                                  stefan, waterDistributionCoeff);
-    //      theta = - (C + compositionRatio*(1-porosity)) / (porosity +
-    //      waterDistributionCoeff*(1-porosity));
-    Real A = compositionRatio * (specificHeatRatio - 1) - stefan;
-    Real B = H + compositionRatio * (1 - 2 * specificHeatRatio) -
-             C * (specificHeatRatio - 1);
-    Real Cc = specificHeatRatio * (compositionRatio + C);
+    {
+      dHdT = 1/specificHeatRatio;
+    }
+    else if (H > H_s && H <= H_e)
+    {
+      dHdT = 0;
+    }
+    else if (H > H_e && H < H_l)
+    {
+      Real porosity = computePorosityMushyLayer( H,  C,  compositionRatio,  specificHeatRatio,
+                                                 stefan,  waterDistributionCoeff);
+//      theta = - (C + compositionRatio*(1-porosity)) / (porosity + waterDistributionCoeff*(1-porosity));
+      Real A = compositionRatio*(specificHeatRatio-1) - stefan;
+      Real B = H + compositionRatio*(1-2*specificHeatRatio) - C*(specificHeatRatio-1);
+      Real Cc = specificHeatRatio*(compositionRatio + C);
 
-    dHdT = pow(porosity, 2) * (C + compositionRatio) * (-2 * A) /
-           (1 + B / sqrt(pow(B, 2) - 4 * A * Cc));
-  }
-  else
-  {
-    dHdT = 1;
-  }
+
+      dHdT = pow(porosity,2) * (C+compositionRatio)*(-2*A)/(1 + B/sqrt(pow(B,2) - 4*A*Cc));
+    }
+    else
+    {
+      dHdT = 1;
+    }
 
   return dHdT;
+
 }
 
 Real MushyLayerParams::computeTemperature(Real H, Real C)
 {
   CH_TIME("MushyLayerParams::computeTemperature");
 
-  Real temperature = ::computeTemperature(
-      H, C, compositionRatio, specificHeatRatio, stefan, waterDistributionCoeff,
-      specificHeatRatio, thetaEutectic, ThetaEutectic);
+  Real temperature = ::computeTemperature(H, C, compositionRatio,  specificHeatRatio,
+                                  stefan,  waterDistributionCoeff,  specificHeatRatio,
+                                  thetaEutectic,  ThetaEutectic);
 
   return temperature;
 }
 
-void MushyLayerParams::computeDiagnosticVars(Real H, Real C, Real T,
-                                             Real porosity, Real Cl, Real Cs)
+void MushyLayerParams::computeDiagnosticVars(Real H, Real C, Real T, Real porosity, Real Cl, Real Cs)
 {
   Real H_s, H_l, H_e;
-  ::computeBoundingEnergy(H, C, H_s, H_l, H_e, specificHeatRatio, stefan,
-                          compositionRatio, waterDistributionCoeff,
-                          thetaEutectic, ThetaEutectic);
+  ::computeBoundingEnergy(H, C, H_s, H_l, H_e,
+                          specificHeatRatio, stefan, compositionRatio, waterDistributionCoeff, thetaEutectic, ThetaEutectic);
   ::computeEnthalpyVars(H, C, porosity, T, Cl, Cs, H_s, H_l, H_e,
-                        specificHeatRatio, stefan, compositionRatio,
-                        waterDistributionCoeff, thetaEutectic, ThetaEutectic);
+                        specificHeatRatio, stefan, compositionRatio, waterDistributionCoeff, thetaEutectic, ThetaEutectic);
 }
+
 
 string MushyLayerParams::getVelocityScale() const
 {
   switch (m_nondimensionalisation)
   {
-  case m_advectiveTime_darcyVel:
-    return s_DARCY_VELOCITY_SCALE;
-    break;
+    case m_advectiveTime_darcyVel:
+      return s_DARCY_VELOCITY_SCALE;
+      break;
 
-  case m_diffusiveTime_advectiveVel:
-    return s_ADVECTIVE_VELOCITY_SCALE;
-    break;
+    case m_diffusiveTime_advectiveVel:
+      return s_ADVECTIVE_VELOCITY_SCALE;
+      break;
 
-  case m_darcyTime_advectiveVel:
-    return s_ADVECTIVE_VELOCITY_SCALE;
-    break;
+    case     m_darcyTime_advectiveVel:
+      return s_ADVECTIVE_VELOCITY_SCALE;
+      break;
 
-  case m_darcyTime_darcyVel:
-    return s_DARCY_VELOCITY_SCALE;
-    break;
+    case  m_darcyTime_darcyVel:
+      return s_DARCY_VELOCITY_SCALE;
+      break;
 
-  case m_buoyancyTime_advectiveVel:
-    return s_ADVECTIVE_VELOCITY_SCALE;
-    break;
+    case  m_buoyancyTime_advectiveVel:
+      return s_ADVECTIVE_VELOCITY_SCALE;
+      break;
 
-  default:
-    MayDay::Error("Unknown nondimensionalisation");
-    return "";
-    break;
+    default:
+      MayDay::Error("Unknown nondimensionalisation");
+      return "";
+      break;
+
   }
+
 }


### PR DESCRIPTION
Cleaned up the code to try an implement the 'split diri' BCs, where two different Dirichlet BC values can be implemented on one side. The code now compiles, which is good news.

mods to: PhysBCUtil.cpp, PhysBCUtil.H, MushyLayerParams.cpp, MushyLayerParams.h

Currently I can successfully implement temperature Diri BCs with my new input values (bcAltValTemperatureLo and bcAltValTemperatureHi), however I am now having a geometry problem.

As it stands regardless of what I input as my intended switch points for the BCs (bcDiriSwitchLo and bcDiriSwitchHi) I am always getting my alternate values applied to the whole sidewall. I've even tried hardcoding a switch point into PhysBCUtil.cpp but to no avail. **I am thinking it may be an issue with my understanding of the getLocation functions, one of which I'm using to try and implement the geometry.** This is also in PhysBCUtil.cpp (Line 884), where I want to implement the alternate values on the sidewall above the diri_switch point (e.g. y >= diri_switch) and the originally defined BC value (base_val) for the rest of the sidewall. I've been stuck on this for a bit, so if you've got any intuition on what the issue could be I think it'll be the last step in getting the MultiDiri BC option up and running.

Cheers,

jacob