### PR TITLE
added MultiDiri BC options and lens solidification geometry

### DIFF
--- a/BCutil/PhysBCUtil.H
+++ b/BCutil/PhysBCUtil.H
@@ -126,6 +126,10 @@ public:
 	   */
 	  MixedBCTemperatureSalinity,
 
+	  /// Multiple Dirichlet Values (#10)
+	  MultiDiri
+
+	  /* jb: Multiple Dirichlet BCs per side, where alternate value is active after diri_switch */
 
 	};
 

--- a/src/MushyLayerParams.cpp
+++ b/src/MushyLayerParams.cpp
@@ -496,6 +496,20 @@ void MushyLayerParams::getParameters()
   ppParams.query("enthalpyPlume", HPlumeInflow);
   ppParams.query("bulkConcPlume", ThetaPlumeInflow);
 
+    //// jb - attempting to add multiple dirichlet BC values option for Enthalpy (maybe Salinity in future)
+    ////    - currently keeping things in one spot, can redistribute after they're checked
+
+    ////        here i'm introducing the boundaries for where the AltVal will occur
+
+    parseBCVals("diriSwitchLo", bcDiriSwitchLo);
+    parseBCVals("diriSwitchHi", bcDiriSwitchHi);
+
+    ////        these are the AltVals
+    parseBCVals("temperatureAltValLo", bcAltValTemperatureLo);
+    parseBCVals("temperatureAltValHi", bcAltValTemperatureHi);
+
+    //// end multidiri mod
+
   //  ParmParse ppBC("bc");
 
   // Define BC objects

--- a/src/MushyLayerParams.h
+++ b/src/MushyLayerParams.h
@@ -517,6 +517,20 @@ public:
   /// Specify start and end of an inflow plume
   Vector<Real> plumeBounds;
 
+    /// For mixed dirichlet boundary conditions
+    /// Specify the location and magnitude of the multi-valued Dirichlet boundary switch
+    /// Location where Dirichlet BCs switch Low edges
+    RealVect    bcDiriSwitchLo,
+
+    /// Location where Dirichlet BCs switch High edges
+    bcDiriSwitchHi,
+
+    /// Deviation from base Dirichlet BC value on Low edges
+    bcAltValTemperatureLo,
+
+    /// Deviation from base Dirichlet BC value on High edges
+    bcAltValTemperatureHi;
+
   /// Velocity boundary conditions (lo side, for each spatial direction)
   Vector<int> bcTypeVelLo,
 

--- a/srcSubcycle/AMRLevelMushyLayer.H
+++ b/srcSubcycle/AMRLevelMushyLayer.H
@@ -272,6 +272,9 @@ public:
   /// Mushy layer with a porous hole in the middle
   void initialDataPorousHole();
 
+  /// Initial data for a pure fluid with top and bottom cold boundaries
+  void initialDataLens();
+
   /// Initial data for a test case with regions of zero porosity
   void initialDataZeroPorosityTest();
 

--- a/srcSubcycle/AMRLevelMushyLayerInit.cpp
+++ b/srcSubcycle/AMRLevelMushyLayerInit.cpp
@@ -1214,6 +1214,22 @@ void AMRLevelMushyLayer::initialDataDefault()
   }
 }
 
+void AMRLevelMushyLayer::initialDataLens()
+{
+    // domain filled with fluid at the liquidus temp (not handcuffed to bottom BC) for top AND bottom freezing
+    Real H =  m_parameters.stefan + 1.01;
+    Real C =  -1.0;
+
+    DataIterator dit = m_grids.dataIterator();
+    for (dit.reset(); dit.ok(); ++dit)
+    {
+        (*m_scalarNew[ScalarVars::m_enthalpy])[dit].setVal(H);
+        (*m_scalarNew[ScalarVars::m_bulkConcentration])[dit].setVal(C);
+
+    }
+
+}
+
 void AMRLevelMushyLayer::initialDataSidewallHeating()
 {
   // heating in x direction, i.e. left/right walls;
@@ -2119,6 +2135,9 @@ void AMRLevelMushyLayer::initialData()
     {
     case 1:
       initialDataPorousHole();
+      break;
+    case 2:
+      initialDataLens();
       break;
     default:
       initialDataDefault();


### PR DESCRIPTION
Modifications include:

- a new initial condition option that simulates top-down and bottom-up solidification (doesn't handcuff initial domain conditions to lower BC conditions)
- new multiple Dirichlet boundary conditions, where two values can be specified as well as a switch point to select where along the boundary the values change