### PR TITLE
fixed BC vector issue and added BC option LinDiri

### DIFF
--- a/BCutil/PhysBCUtil.H
+++ b/BCutil/PhysBCUtil.H
@@ -127,9 +127,14 @@ public:
 	  MixedBCTemperatureSalinity,
 
 	  /// Multiple Dirichlet Values (#10)
-	  MultiDiri
+	  MultiDiri,
 
-	  /* jb: Multiple Dirichlet BCs per side, where alternate value is active after diri_switch */
+	  /** jb: Multiple Dirichlet BCs per side, where alternate value is active after diri_switch */
+
+	  /// Linear Dirichlet BC (#11)
+	  /** jb: Modification of MultDiri, where BC is a linear temperature that varies from the base temperature
+      *  value at the DiriSwitch point to a temperature defined at the edge corners */
+	  LinDiri
 
 	};
 

--- a/src/MushyLayerParams.cpp
+++ b/src/MushyLayerParams.cpp
@@ -104,6 +104,14 @@ MushyLayerParams::MushyLayerParams()
   m_scalarBCTypes.push_back("noflux");
   m_scalarBCTypes.push_back("open");
   m_scalarBCTypes.push_back("inflow");
+  m_scalarBCTypes.push_back("robin");
+  m_scalarBCTypes.push_back("variableFlux");
+  m_scalarBCTypes.push_back("fixedTemperature");
+  m_scalarBCTypes.push_back("temperatureFlux");
+  m_scalarBCTypes.push_back("temperatureFluxRadiation");
+  m_scalarBCTypes.push_back("mixedBCTemperatureSalinity");
+  m_scalarBCTypes.push_back("multiDiri");
+  m_scalarBCTypes.push_back("linDiri");
 
   m_vectorBCTypes.push_back("noflow");
   m_vectorBCTypes.push_back("inflowVelocity");
@@ -509,6 +517,17 @@ void MushyLayerParams::getParameters()
     parseBCVals("temperatureAltValHi", bcAltValTemperatureHi);
 
     //// end multidiri mod
+
+    //// jb - adding linear dirichlet boundary conditions, using defined corner temperature values
+    ////      to describe a linear dirichlet boundary condition from the point of the DiriSwitch to the
+    ////      corner temperature
+
+    parseBCVals("temperatureCornerValLo",bcCornerTemperatureLo);
+    parseBCVals("temperatureCornerValHi",bcCornerTemperatureHi);
+
+    parseBCVals("domainSize",bcDomainSize);
+
+    //// end LinDiri mod
 
   //  ParmParse ppBC("bc");
 

--- a/src/MushyLayerParams.h
+++ b/src/MushyLayerParams.h
@@ -529,7 +529,17 @@ public:
     bcAltValTemperatureLo,
 
     /// Deviation from base Dirichlet BC value on High edges
-    bcAltValTemperatureHi;
+    bcAltValTemperatureHi,
+
+    /// Boundary temperatures at corners of domain (top left, bottom right) - Low edges (for LinDiri)
+    bcCornerTemperatureLo,
+
+    /// Boundary temperatures at corners of domain (top right, top right) - High edges (for LinDiri)
+    bcCornerTemperatureHi,
+
+    /// Domain size [y x] - possibly redundant as this is just [domainHeight domainWidth], but not
+    ///                     sure how to call those into this vector
+    bcDomainSize;
 
   /// Velocity boundary conditions (lo side, for each spatial direction)
   Vector<int> bcTypeVelLo,


### PR DESCRIPTION
Changed issue with the string vector for BCs that was causing issue.

Also added a new BC (LinDiri), which is an adaptation of the MultiDiri BC. New BC defines temperatures at the corners of the domains and creates a Dirichlet boundary condition that varies linearly from the DiriSwitch point (baseVal temperature )to the newly defined corner temperature.